### PR TITLE
QOL update 1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# IDE
 .pio
 .vscode/settings.json
 .vscode/extensions.json
@@ -6,7 +7,10 @@
 .vscode/launch.json
 .vscode/ipch
 
+# python
 *pyc
 *.dict
 
+# packages
 *.egg-info
+build

--- a/jescore_cli/jescore_cli/common.py
+++ b/jescore_cli/jescore_cli/common.py
@@ -21,7 +21,7 @@ KNOWN_HOSTS =  {"Electrosmith Daisy Seed": "VID:PID=0483:5740",
                 "Generic board with CH340 USB-to-UART converter": "VID:PID=1A86:7523",
                 "USB enhanced serial CH343": "VID:PID=1A86:55D3"}
 CLI_PREFIX_CLIENT = "[jes-core]:\t"
-CLI_PREFIX_MCU = "jes-core $"
+CLI_PREFIX_MCU = "jes-core $ "
 CLI_CLIENT_IDENTIFIER = "@py" # unused
 
 

--- a/jescore_cli/jescore_cli/jescore_cli.py
+++ b/jescore_cli/jescore_cli/jescore_cli.py
@@ -46,7 +46,7 @@ class CjescoreCli:
             return f"/dev/{port}"
         return port
     
-    def __uartTransceive(self, msg: str, waitTime: float = 0.01) -> str:
+    def uartTransceive(self, msg: str, waitTime: float = 0.01) -> str:
         port_name = self.__getPort()
         self.__vPrint(f"Sending raw string '{msg}' to jes-core on port {port_name}")
         ser = serial.Serial(port_name, baudrate=self.baudrate, timeout=waitTime)
@@ -69,7 +69,7 @@ class CjescoreCli:
 
     def run(self, command):
         if command:
-            stat = self.__uartTransceive(command)
+            stat = self.uartTransceive(command)
             self.__vPrint(f"Received raw string {stat}")
         else:
             print("Error: Command not specified.")

--- a/jescore_cli/jescore_cli/jescore_cli.py
+++ b/jescore_cli/jescore_cli/jescore_cli.py
@@ -50,6 +50,7 @@ class CjescoreCli:
         port_name = self.__getPort()
         self.__vPrint(f"Sending raw string '{msg}' to jes-core on port {port_name}")
         ser = serial.Serial(port_name, baudrate=self.baudrate, timeout=waitTime)
+        ser.flush()
         ser.setRTS(False)
         ser.write(msg.encode())
         stat = ""

--- a/jescore_cli/pyproject.toml
+++ b/jescore_cli/pyproject.toml
@@ -9,7 +9,7 @@ description = "CLI for jes-core serial communication"
 authors = [
     { name = "jake-is-ESD-protected", email = "jake@jesdev.io" }
 ]
-dependencies = ["pyserial"]
+dependencies = ["pyserial", "pytest"]
 
 [project.urls]
 "Homepage" = "https://jesdev.io"

--- a/jescore_cli/tests/test_cli.py
+++ b/jescore_cli/tests/test_cli.py
@@ -1,0 +1,53 @@
+from jescore_cli.jescore_cli import CjescoreCli
+from jescore_cli.common import CLI_PREFIX_MCU
+import platform
+import pytest
+
+cli = CjescoreCli()
+
+def test_cli_init():
+    assert cli.os_type == platform.system()
+
+def test_cli_echo():
+    cli.uartTransceive("provoke flush")
+    msg = "echo test"
+    stat = cli.uartTransceive(msg)
+    assert stat[0] == "test"
+    assert stat[1] == CLI_PREFIX_MCU
+
+def test_cli_help():
+    msg = "help"
+    stat = cli.uartTransceive(msg)
+    assert stat[-1] == CLI_PREFIX_MCU
+    stat = ' '.join(stat) # as single string
+    assert "Available jobs" in stat
+    assert "(user)" in stat
+    assert "(base)" in stat
+    assert "echo" in stat
+    assert "help" in stat
+    assert "stats" in stat
+
+def test_cli_stats():
+    msg = "stats"
+    stat = cli.uartTransceive(msg)
+    assert stat[-1] == CLI_PREFIX_MCU
+    stat = ' '.join(stat)
+    assert "name" in stat
+    assert "handle" in stat
+    assert "memory" in stat
+    assert "prio" in stat
+    assert "loop" in stat
+    assert "instances" in stat
+    assert "error" in stat
+    
+    assert "echo" in stat
+    assert "cliserver" in stat
+    assert "stats" in stat
+    assert "help" in stat
+    assert "headerprint" in stat
+    assert "initcli" in stat
+    assert "errorhandler" in stat
+    assert "core" in stat 
+
+if __name__ == "__main__":
+    pytest.main()

--- a/lib/base_jobs/base_jobs.cpp
+++ b/lib/base_jobs/base_jobs.cpp
@@ -15,17 +15,6 @@ void __base_job_echo(void* p){
 }
 
 
-jes_err_t __base_job_echo_wrapper(const char* s, origin_t o){
-    job_struct_t* printer = __job_get_job_by_name(PRINT_JOB_NAME);
-    job_struct_t* core_job = __job_get_job_by_name(CORE_JOB_NAME);
-    jes_err_t stat = __job_copy_str(printer->args, (char*)s, __MAX_JOB_ARGS_LEN_BYTE);
-    if(stat != e_err_no_err){ return stat; }
-    printer->caller = o;
-    __job_notify_with_job(core_job, printer, false);
-    return e_err_no_err;
-}
-
-
 void __base_job_help(void* p){
     char desc[__MAX_JOB_ARGS_LEN_BYTE*2] = {0};
 

--- a/lib/base_jobs/base_jobs.cpp
+++ b/lib/base_jobs/base_jobs.cpp
@@ -46,7 +46,7 @@ void __base_job_stats(void* p){
     job_struct_t** job_list = __core_get_job_list();
     job_struct_t* cur = *job_list;
 
-    sprintf(desc, "\x1b[1mname\t\thandle\t\tmemory\tprio\tloop\tinstances\x1b[0m\n\r");
+    sprintf(desc, "\x1b[1mname\t\thandle\t\tmemory\tprio\tloop\tinstances\terror\x1b[0m\n\r");
     uart_unif_write((uint8_t*)desc, strlen(desc));
     uint8_t* clr;
     while(cur != NULL){
@@ -65,7 +65,7 @@ void __base_job_stats(void* p){
         if(cur->role == e_role_core) clr = CLR_Gr;
         if(cur->role == e_role_base) clr = CLR_Y;
         if(cur->role == e_role_user) clr = CLR_G;
-        sprintf(desc, "%s\t\t%s%s%x%s%d\t%d\t%d\t%d%s\n\r", 
+        sprintf(desc, "%s\t\t%s%s%x%s%d\t%d\t%d\t%d\t\t%d%s\n\r", 
                 clr,
                 cur->name, 
                 spacing_name,
@@ -75,6 +75,7 @@ void __base_job_stats(void* p){
                 cur->priority,
                 cur->is_loop,
                 cur->instances,
+                cur->error,
                 CLR_X);
         uart_unif_write((uint8_t*)desc, strlen(desc));
         cur = cur->pn;

--- a/lib/base_jobs/base_jobs.cpp
+++ b/lib/base_jobs/base_jobs.cpp
@@ -4,6 +4,7 @@
 #include "string.h"
 #include "job_names.h"
 #include "core.h"
+#include "cli.h"
 
 
 void __base_job_echo(void* p){
@@ -47,6 +48,7 @@ void __base_job_stats(void* p){
 
     sprintf(desc, "\x1b[1mname\t\thandle\t\tmemory\tprio\tloop\tinstances\x1b[0m\n\r");
     uart_unif_write((uint8_t*)desc, strlen(desc));
+    uint8_t* clr;
     while(cur != NULL){
         if(strlen(cur->name) < 8){
             spacing_name[1] = '\t';
@@ -60,7 +62,11 @@ void __base_job_stats(void* p){
         else{
             spacing_addr[1] = 0;
         }
-        sprintf(desc, "\t\t%s%s%x%s%d\t%d\t%d\t%d\n\r", 
+        if(cur->role == e_role_core) clr = CLR_Gr;
+        if(cur->role == e_role_base) clr = CLR_Y;
+        if(cur->role == e_role_user) clr = CLR_G;
+        sprintf(desc, "%s\t\t%s%s%x%s%d\t%d\t%d\t%d%s\n\r", 
+                clr,
                 cur->name, 
                 spacing_name,
                 cur->handle, 
@@ -68,7 +74,8 @@ void __base_job_stats(void* p){
                 cur->mem_size, 
                 cur->priority,
                 cur->is_loop,
-                cur->instances);
+                cur->instances,
+                CLR_X);
         uart_unif_write((uint8_t*)desc, strlen(desc));
         cur = cur->pn;
     }

--- a/lib/base_jobs/base_jobs.h
+++ b/lib/base_jobs/base_jobs.h
@@ -6,8 +6,6 @@
 
 void __base_job_echo(void* p);
 
-jes_err_t __base_job_echo_wrapper(const char* s, origin_t o);
-
 void __base_job_help(void* p);
 
 void __base_job_stats(void* p);

--- a/lib/base_jobs/base_jobs.h
+++ b/lib/base_jobs/base_jobs.h
@@ -2,7 +2,7 @@
 #define _BASE_JOBS_H_
 
 #include "commands.h"
-#include "err.h"
+#include "jes_err.h"
 
 void __base_job_echo(void* p);
 

--- a/lib/cli/cli.cpp
+++ b/lib/cli/cli.cpp
@@ -23,6 +23,7 @@ void cli_set_sess_state(uint8_t sess_state){
 void init_cli(void* p){
     job_list = (job_struct_t**)p;
     uart_unif_init(BAUDRATE, CLI_BUF_SIZE, CLI_BUF_SIZE, (void*)&queue_uart);
+    uart_unif_write((uint8_t*)BOOT_MSG, sizeof(BOOT_MSG));
     __job_register_job(SERIAL_READ_NAME, 4096, 1, cli_server, true, e_role_core);
     __job_register_job(PRINT_JOB_NAME, 4096, 1, __base_job_echo, false, e_role_base);
     job_struct_t* pj_to_do = __job_get_job_by_name(SERIAL_READ_NAME);

--- a/lib/cli/cli.cpp
+++ b/lib/cli/cli.cpp
@@ -35,7 +35,6 @@ void init_cli(void* p){
 void cli_server(void *pvParameters)
 {
     char raw_str[__MAX_JOB_ARGS_LEN_BYTE] = {0};
-    char* cmd_str = &raw_str[0];
     char* arg_str = NULL;
     job_struct_t* pj_to_do = NULL;
     uart_event_t event;
@@ -80,7 +79,7 @@ void cli_server(void *pvParameters)
                 if(ws_i != -1){
                     raw_str[ws_i] = '\0';
                 }
-                pj_to_do = __job_get_job_by_name(cmd_str);
+                pj_to_do = __job_get_job_by_name(raw_str); // is only read to '\0'
                 if(pj_to_do){
                     pj_to_do->caller = e_origin_cli;
                     if((uint16_t)ws_i < (event.size-1)){

--- a/lib/cli/cli.h
+++ b/lib/cli/cli.h
@@ -14,6 +14,15 @@
 #define CLI_HEADER      "\rjes-core $ "
 #endif
 
+#define CLR_R   (uint8_t*)"\x1b[31m"
+#define CLR_G   (uint8_t*)"\x1b[32m"
+#define CLR_Y   (uint8_t*)"\x1b[33m"
+#define CLR_B   (uint8_t*)"\x1b[34m"
+#define CLR_M   (uint8_t*)"\x1b[35m"
+#define CLR_C   (uint8_t*)"\x1b[36m"
+#define CLR_Gr  (uint8_t*)"\x1b[90m"
+#define CLR_X   (uint8_t*)"\x1b[0m"
+
 uint8_t cli_get_sess_state(void);
 void cli_set_sess_state(uint8_t sess_state);
 void init_cli(void* p);

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -4,7 +4,7 @@
 /// @file Main core acting as finite state machine.
 
 #include "Arduino.h"
-#include "err.h"
+#include "jes_err.h"
 #include "commands.h"
 #include "job_driver.h"
 

--- a/lib/jes_err/jes_err.h
+++ b/lib/jes_err/jes_err.h
@@ -1,5 +1,5 @@
-#ifndef _ERR_H_
-#define _ERR_H_
+#ifndef _JES_ERR_H_
+#define _JES_ERR_H_
 
 /// @file Error types.
 

--- a/lib/jescore_api/jescore_api.cpp
+++ b/lib/jescore_api/jescore_api.cpp
@@ -45,11 +45,6 @@ jes_err_t register_and_launch_job(const char* name,
 }
 
 
-jes_err_t jesprint(const char* s){
-    return __base_job_echo_wrapper(s, e_origin_api);
-}
-
-
 jes_err_t set_args(char* s){
     TaskHandle_t caller = xTaskGetCurrentTaskHandle();
     job_struct_t* pj = __job_get_job_by_handle(caller);

--- a/lib/jescore_api/jescore_api.h
+++ b/lib/jescore_api/jescore_api.h
@@ -68,14 +68,14 @@ jes_err_t set_args(char* s);
 char* get_args(void);
 
 
-/// @brief Set the field `optional` of the job.
+/// @brief Set the field `param` of the job.
 /// @param p: Arbitrary reference to parameter.
 /// @return status, `e_no_err` if OK.
 jes_err_t set_param(void* p);
 
 
-/// @brief Get the field `optional` of the job.
-/// @return Pointer to `optional` field of the job.
+/// @brief Get the field `param` of the job.
+/// @return Pointer to `param` field of the job.
 /// @attention Will return NULL on error.
 void* get_param(void);
 

--- a/lib/jescore_api/jescore_api.h
+++ b/lib/jescore_api/jescore_api.h
@@ -4,7 +4,7 @@
 /// @file Top API layer for user access.
 
 #include "core.h"
-#include "err.h"
+#include "jes_err.h"
 #include "job_driver.h"
 
 /// @brief Start the core and all of its abilities.

--- a/lib/jescore_api/jescore_api.h
+++ b/lib/jescore_api/jescore_api.h
@@ -46,12 +46,6 @@ jes_err_t register_and_launch_job(const char* name,
                                   bool is_loop);
 
 
-/// @brief Send string to printing job.
-/// @param s: string to print.
-/// @return Status. Returns `e_no_err` in case of successful launch.
-jes_err_t jesprint(const char* s);
-
-
 /// @brief Set the field `args` of the job.
 /// @param s: String to insert into `args` field.
 /// @return status, `e_no_err` if OK.

--- a/lib/job_driver/job_driver.cpp
+++ b/lib/job_driver/job_driver.cpp
@@ -31,7 +31,7 @@ jes_err_t __job_register_job(const char* n,
     pj->instances = 0;
     pj->role = role;
     pj->caller = e_origin_undefined;
-    pj->optional = NULL;
+    pj->param = NULL;
     pj->error = e_err_no_err;
     pj->notif_queue = xQueueCreate(MAX_JOB_NOTIF_QUEUE_SIZE, sizeof(void*));
     if(pj->notif_queue == NULL) { return e_err_mem_null; }
@@ -216,12 +216,12 @@ char* __job_get_args(job_struct_t* pj){
 
 jes_err_t __job_set_param(void* p, job_struct_t* pj){
     if(pj == NULL){ return e_err_is_zero; }
-    pj->optional = p;
+    pj->param = p;
     return e_err_no_err;
 }
 
 
 void* __job_get_param(job_struct_t* pj){
     if(pj == NULL){ return NULL; }
-    return pj->optional;
+    return pj->param;
 }

--- a/lib/job_driver/job_driver.h
+++ b/lib/job_driver/job_driver.h
@@ -4,7 +4,7 @@
 /// @file Driver for jobs. Handles job registration, launching and inter-job communication.
 
 #include <Arduino.h>
-#include "err.h"
+#include "jes_err.h"
 #include "commands.h"
 
 #define __GET_SAFE_SIZE(SIZE, LIMIT) ((SIZE)<=(LIMIT)?(SIZE):(LIMIT))

--- a/lib/job_driver/job_driver.h
+++ b/lib/job_driver/job_driver.h
@@ -41,7 +41,7 @@ typedef enum{
 /// @param instances (uint8_t): number of active instances of same job type.
 /// @param role (e_role_t): Role of job in usage context.
 /// @param caller (origin_t): Requesting entity of job.
-/// @param optional (void*): Optional information.
+/// @param param (void*): Optional information.
 /// @param error (jes_err_t): Error associated with fault from/in job. Gets used by the error handler
 /// @param notif_queue (QueueHandle_t): Job's notification queue handle.
 /// @param pn (job_struct_t*): Pointer to next job (llist).
@@ -56,7 +56,7 @@ typedef struct job_struct_t{
     uint8_t instances = 0;
     e_role_t role = e_role_core;
     origin_t caller = e_origin_undefined;
-    void* optional = NULL;
+    void* param = NULL;
     jes_err_t error = e_err_no_err;
     QueueHandle_t notif_queue = NULL;
     struct job_struct_t* pn = NULL;
@@ -190,16 +190,16 @@ jes_err_t __job_set_args(char* s, job_struct_t* pj);
 char* __job_get_args(job_struct_t* pj);
 
 
-/// @brief Set the field `optional` of the job.
+/// @brief Set the field `param` of the job.
 /// @param p: Arbitrary reference to parameter.
 /// @param pj: Pointer to job. 
 /// @return status, `e_no_err` if OK.
 jes_err_t __job_set_param(void* p, job_struct_t* pj);
 
 
-/// @brief Get the field `optional` of the job.
+/// @brief Get the field `param` of the job.
 /// @param pj: Pointer to job. 
-/// @return Pointer to `optional` field of the job.
+/// @return Pointer to `param` field of the job.
 /// @attention Will return NULL on error.
 void* __job_get_param(job_struct_t* pj);
 

--- a/lib/unified/uart.h
+++ b/lib/unified/uart.h
@@ -28,6 +28,10 @@ inline int32_t uart_unif_init(uint32_t baud, uint32_t rx_buf_len, uint32_t tx_bu
     if(stat != ESP_OK){
         return (int32_t)stat;
     }
+    stat = uart_flush(BASE_UART);
+    if(stat != ESP_OK){
+        return (int32_t)stat;
+    }
     return 0;
 }
 
@@ -39,8 +43,12 @@ inline int32_t uart_unif_read(uint8_t* buf, uint32_t len, uint32_t timeout){
     return uart_read_bytes(BASE_UART, buf, len, (TickType_t)timeout);
 }
 
-inline int32_t uart_unif_flush(void){
+inline int32_t uart_unif_flush_inp(void){
     return uart_flush_input(BASE_UART);
+}
+
+inline int32_t uart_unif_flush(void){
+    return uart_flush(BASE_UART);
 }
 
 #elif defined(__AVR__)

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "jes-core",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "FreeRTOS attached core for easier multitasking and native CLI support",
     "keywords": "core, FreeRTOS",
     "repository":
@@ -27,7 +27,7 @@
           "-I lib/cli",
           "-I lib/commands",
           "-I lib/core",
-          "-I lib/err",
+          "-I lib/jes_err",
           "-I lib/jescore_api",
           "-I lib/job_driver",
           "-I lib/job_names",

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,9 @@ platform = espressif32
 framework = arduino
 upload_speed = 921600
 monitor_speed = 115200
+build_flags = 
+    -Ilib/commands
+    -Ilib/jes_err
 
 [env:az-delivery-devkit-v4-release]
 board = az-delivery-devkit-v4

--- a/test/common_test.h
+++ b/test/common_test.h
@@ -20,7 +20,6 @@ void test_job_stats(void);
 
 void test_register_job(void);
 void test_launch_job(void);
-void test_jesprint(void);
 void test_set_get_args(void);
 void test_set_get_params(void);
 void test_core_job_launch_prohibited(void);

--- a/test/test_api_functions.cpp
+++ b/test/test_api_functions.cpp
@@ -146,32 +146,6 @@ void test_launch_job(void){
 }
 
 
-void test_jesprint(void){
-    jes_err_t stat = jesprint(DUMMY_PRINT);
-    TEST_ASSERT_EQUAL_INT(e_err_no_err, stat);
-    vTaskDelay(10 / portTICK_PERIOD_MS);
-    
-    char dummy[__MAX_JOB_ARGS_LEN_BYTE] = {0};
-    strcpy(dummy, DUMMY_PRINT);
-    job_struct_t* pj = __job_get_job_by_name(PRINT_JOB_NAME);
-    TEST_ASSERT_EQUAL_STRING(PRINT_JOB_NAME, pj->name);
-    TEST_ASSERT_EQUAL_HEX32(NULL, pj->handle);
-    TEST_ASSERT_EQUAL_UINT32(4096, pj->mem_size);
-    TEST_ASSERT_EQUAL_UINT8(1, pj->priority);
-    TEST_ASSERT_EQUAL_HEX32(__base_job_echo, pj->function);
-    TEST_ASSERT_EQUAL_INT8_ARRAY(dummy, pj->args, __MAX_JOB_ARGS_LEN_BYTE);
-    TEST_ASSERT_EQUAL_UINT8(0, pj->is_loop);
-    TEST_ASSERT_EQUAL_UINT8(0, pj->instances);
-    TEST_ASSERT_EQUAL_INT(e_role_base, pj->role);
-    TEST_ASSERT_EQUAL_INT(e_origin_api, pj->caller);
-    TEST_ASSERT_EQUAL_HEX32(NULL, pj->param);
-    TEST_ASSERT_EQUAL_INT(e_err_no_err, pj->error);
-
-    stat = jesprint("This string is too long and should therefore not be printable in the current state of jesprint!");
-    TEST_ASSERT_EQUAL_INT(e_err_too_long, stat);
-}
-
-
 void test_set_get_args(void){
     char dummy[__MAX_JOB_ARGS_LEN_BYTE] = {0};
     strcpy(dummy, DUMMY_PRINT);

--- a/test/test_api_functions.cpp
+++ b/test/test_api_functions.cpp
@@ -82,7 +82,7 @@ void test_register_job(void){
     TEST_ASSERT_EQUAL_UINT8(0, pj->instances);
     TEST_ASSERT_EQUAL_INT(e_role_user, pj->role);
     TEST_ASSERT_EQUAL_INT(e_origin_undefined, pj->caller);
-    TEST_ASSERT_EQUAL_HEX32(NULL, pj->optional);
+    TEST_ASSERT_EQUAL_HEX32(NULL, pj->param);
     TEST_ASSERT_EQUAL_INT(e_err_no_err, pj->error);
 
     stat = register_job(DUMMY_JOB_LOOP_NAME,
@@ -103,7 +103,7 @@ void test_register_job(void){
     TEST_ASSERT_EQUAL_UINT8(0, pj->instances);
     TEST_ASSERT_EQUAL_INT(e_role_user, pj->role);
     TEST_ASSERT_EQUAL_INT(e_origin_undefined, pj->caller);
-    TEST_ASSERT_EQUAL_HEX32(NULL, pj->optional);
+    TEST_ASSERT_EQUAL_HEX32(NULL, pj->param);
     TEST_ASSERT_EQUAL_INT(e_err_no_err, pj->error);
 }
 
@@ -124,7 +124,7 @@ void test_launch_job(void){
     TEST_ASSERT_EQUAL_UINT8(1, pj->instances);
     TEST_ASSERT_EQUAL_INT(e_role_user, pj->role);
     TEST_ASSERT_EQUAL_INT(e_origin_api, pj->caller);
-    TEST_ASSERT_EQUAL_HEX32(NULL, pj->optional);
+    TEST_ASSERT_EQUAL_HEX32(NULL, pj->param);
     TEST_ASSERT_EQUAL_INT(e_err_no_err, pj->error);
 
     stat = launch_job(DUMMY_JOB_LOOP_NAME);
@@ -141,7 +141,7 @@ void test_launch_job(void){
     TEST_ASSERT_EQUAL_UINT8(1, pj->instances);
     TEST_ASSERT_EQUAL_INT(e_role_user, pj->role);
     TEST_ASSERT_EQUAL_INT(e_origin_api, pj->caller);
-    TEST_ASSERT_EQUAL_HEX32(NULL, pj->optional);
+    TEST_ASSERT_EQUAL_HEX32(NULL, pj->param);
     TEST_ASSERT_EQUAL_INT(e_err_no_err, pj->error);
 }
 
@@ -164,7 +164,7 @@ void test_jesprint(void){
     TEST_ASSERT_EQUAL_UINT8(0, pj->instances);
     TEST_ASSERT_EQUAL_INT(e_role_base, pj->role);
     TEST_ASSERT_EQUAL_INT(e_origin_api, pj->caller);
-    TEST_ASSERT_EQUAL_HEX32(NULL, pj->optional);
+    TEST_ASSERT_EQUAL_HEX32(NULL, pj->param);
     TEST_ASSERT_EQUAL_INT(e_err_no_err, pj->error);
 
     stat = jesprint("This string is too long and should therefore not be printable in the current state of jesprint!");
@@ -192,7 +192,7 @@ void test_set_get_params(void){
 
     jes_err_t stat = __job_set_param(&value, pj);   // API call only works within jobs
     TEST_ASSERT_EQUAL_INT(e_err_no_err, stat);
-    uint32_t* internal_val = (uint32_t*)pj->optional;
+    uint32_t* internal_val = (uint32_t*)pj->param;
     TEST_ASSERT_EQUAL_INT(value, *internal_val);
 
     uint32_t ret = *(uint32_t*)__job_get_param(pj); // API call only works within jobs

--- a/test/test_core_startup.cpp
+++ b/test/test_core_startup.cpp
@@ -47,7 +47,7 @@ void test_job_core(void){
     TEST_ASSERT_EQUAL_UINT8(1, pj->instances);
     TEST_ASSERT_EQUAL_INT(e_role_core, pj->role);
     TEST_ASSERT_EQUAL_INT(e_origin_core, pj->caller);
-    TEST_ASSERT_EQUAL_HEX32(NULL, pj->optional);
+    TEST_ASSERT_EQUAL_HEX32(NULL, pj->param);
     TEST_ASSERT_EQUAL_INT(e_err_no_err, pj->error);
 }
 
@@ -65,7 +65,7 @@ void test_job_error_handler(void){
     TEST_ASSERT_EQUAL_UINT8(0, pj->instances);
     TEST_ASSERT_EQUAL_INT(e_role_core, pj->role);
     TEST_ASSERT_EQUAL_INT(e_origin_undefined, pj->caller);
-    TEST_ASSERT_EQUAL_HEX32(NULL, pj->optional);
+    TEST_ASSERT_EQUAL_HEX32(NULL, pj->param);
     TEST_ASSERT_EQUAL_INT(e_err_no_err, pj->error);
 }
 
@@ -83,7 +83,7 @@ void test_job_init_cli(void){
     TEST_ASSERT_EQUAL_UINT8(0, pj->instances);
     TEST_ASSERT_EQUAL_INT(e_role_core, pj->role);
     TEST_ASSERT_EQUAL_INT(e_origin_core, pj->caller);
-    TEST_ASSERT_EQUAL_HEX32(NULL, pj->optional);
+    TEST_ASSERT_EQUAL_HEX32(NULL, pj->param);
     TEST_ASSERT_EQUAL_INT(e_err_no_err, pj->error);
 }
 
@@ -101,7 +101,7 @@ void test_job_reprint_header(void){
     TEST_ASSERT_EQUAL_UINT8(0, pj->instances);
     TEST_ASSERT_EQUAL_INT(e_role_core, pj->role);
     TEST_ASSERT_EQUAL_INT(e_origin_undefined, pj->caller);
-    TEST_ASSERT_EQUAL_HEX32(NULL, pj->optional);
+    TEST_ASSERT_EQUAL_HEX32(NULL, pj->param);
     TEST_ASSERT_EQUAL_INT(e_err_no_err, pj->error);
 }
 
@@ -119,7 +119,7 @@ void test_job_help(void){
     TEST_ASSERT_EQUAL_UINT8(0, pj->instances);
     TEST_ASSERT_EQUAL_INT(e_role_base, pj->role);
     TEST_ASSERT_EQUAL_INT(e_origin_undefined, pj->caller);
-    TEST_ASSERT_EQUAL_HEX32(NULL, pj->optional);
+    TEST_ASSERT_EQUAL_HEX32(NULL, pj->param);
     TEST_ASSERT_EQUAL_INT(e_err_no_err, pj->error);
 }
 
@@ -137,6 +137,6 @@ void test_job_stats(void){
     TEST_ASSERT_EQUAL_UINT8(0, pj->instances);
     TEST_ASSERT_EQUAL_INT(e_role_base, pj->role);
     TEST_ASSERT_EQUAL_INT(e_origin_undefined, pj->caller);
-    TEST_ASSERT_EQUAL_HEX32(NULL, pj->optional);
+    TEST_ASSERT_EQUAL_HEX32(NULL, pj->param);
     TEST_ASSERT_EQUAL_INT(e_err_no_err, pj->error);
 }

--- a/test/test_runner.cpp
+++ b/test/test_runner.cpp
@@ -41,7 +41,6 @@ void setup()
     // API functions
     RUN_TEST(test_register_job);
     RUN_TEST(test_launch_job);
-    RUN_TEST(test_jesprint);
     RUN_TEST(test_set_get_args);
     RUN_TEST(test_set_get_params);
     RUN_TEST(test_core_job_launch_prohibited);


### PR DESCRIPTION
### Adds these features
- Client side testing for CLI
- CLI is now clean for terminal use after unit tests
- `jescore stats` is now colorful
- Last known error per job is now listed in `jescore stats`

### Changes
- `optional` is now `param`
- `err.h` is now `jes_err.h`
- 

### Removes
- `jesprint`. Use `uart_unif_write` directly if needed.