### PR TITLE
hotfix: ignore local clone of freertos

### DIFF
--- a/library.json
+++ b/library.json
@@ -23,7 +23,8 @@
         ".pio",
         ".venv*",
         ".vscode",
-        "jescore.wiki"
+        "jescore.wiki",
+        "FreeRTOS"
       ]
     },
     "headers": [


### PR DESCRIPTION
This is a hotfix I only noticed after `pio pkg publish` was broken.